### PR TITLE
Fix missing return value in non-void function

### DIFF
--- a/src/fuente2.cc
+++ b/src/fuente2.cc
@@ -417,8 +417,7 @@ char * fuente2 :: saltar_palabra (char * cadena)
 			return cadena + i;
 	}
 
-	if (cadena [i] == '\0')
-		return NULL;
+	return NULL;
 }
 
 void fuente2 :: imprimir (SDL_Surface * dst, char * cadena, int x, \


### PR DESCRIPTION
The function is non void, so gcc 10 complains about a missing return value.